### PR TITLE
Update test dependencies to latest versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,6 +8,13 @@
         "reportgenerator"
       ],
       "rollForward": false
+    },
+    "dotnet-coverage": {
+      "version": "18.6.2",
+      "commands": [
+        "dotnet-coverage"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,15 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
+      - name: Restore .NET tools
+        run: dotnet tool restore
+
       - name: Build
         run: dotnet build --no-restore --configuration Release
 
       - name: Test
-        run: dotnet test --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=test-results.trx" --collect:"XPlat Code Coverage"
+        shell: bash
+        run: dotnet dotnet-coverage collect --output-format cobertura --output TestResults/coverage.cobertura.xml "dotnet test --no-build --configuration Release --verbosity normal --logger \"trx;LogFileName=test-results.trx\""
 
       - name: Test Summary
         if: always() && matrix.os == 'ubuntu-latest'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,11 +7,10 @@
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
-    <PackageVersion Include="IndexRange" Version="1.1.0" />
+    <PackageVersion Include="IndexRange" Version="1.1.1" />
     <PackageVersion Include="Nullable" Version="1.3.1" />
     <!-- Testing -->
-    <PackageVersion Include="MSTest" Version="4.1.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Verify.MSTest" Version="31.12.5" />
+    <PackageVersion Include="MSTest" Version="4.2.1" />
+    <PackageVersion Include="Verify.MSTest" Version="31.16.1" />
   </ItemGroup>
 </Project>

--- a/tests/TagLibSharp2.Tests/TagLibSharp2.Tests.csproj
+++ b/tests/TagLibSharp2.Tests/TagLibSharp2.Tests.csproj
@@ -11,7 +11,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="MSTest" />
-		<PackageReference Include="coverlet.collector" PrivateAssets="all" />
 		<PackageReference Include="PublicApiGenerator" />
 		<PackageReference Include="Verify.MSTest" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary
- Update MSTest from 4.0.2 to 4.1.0
- Update coverlet.collector from 6.0.4 to 8.0.0
- Update Verify.MSTest from 31.9.3 to 31.13.2

## Test plan
- [ ] Verify `dotnet build` succeeds
- [ ] Verify `dotnet test` passes all tests